### PR TITLE
Add openFDA drug fetch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ This repository contains a simple Tetris implementation that runs entirely in yo
 Open `index.html` in any modern browser to play Tetris. Use the arrow keys to move and rotate the pieces. The game ends when the stack of pieces reaches the top of the board.
 
 To try the Codenames demo, open `codenames.html` in a browser. Click on the cards to reveal their colors and use the **Casus baxışı** button to toggle the spymaster view.
+
+## Fetching FDA Drugs
+
+Run `python3 fetch_drugs.py` to retrieve a list of drugs from the [openFDA](https://open.fda.gov/) API. The script prints the brand name, manufacturer, and application number for each entry.
+
+**Note:** Internet access is required for this script to succeed. If network requests fail, ensure you have connectivity or try again later.

--- a/fetch_drugs.py
+++ b/fetch_drugs.py
@@ -1,0 +1,30 @@
+import json
+import sys
+from urllib.request import urlopen, Request
+
+API_URL = "https://api.fda.gov/drug/drugsfda.json?limit=100"
+
+
+def fetch_drugs(url):
+    req = Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    with urlopen(req) as resp:
+        return json.load(resp)
+
+
+def main():
+    try:
+        data = fetch_drugs(API_URL)
+        results = data.get('results', [])
+        for entry in results:
+            app = entry.get('openfda', {})
+            brand = app.get('brand_name', ['Unknown'])[0]
+            manufacturer = app.get('manufacturer_name', ['Unknown'])[0]
+            app_num = entry.get('application_number', 'N/A')
+            print(f"{brand} - {manufacturer} (Application: {app_num})")
+    except Exception as e:
+        print("Failed to fetch data from open.fda.gov:", e, file=sys.stderr)
+        print("Ensure network access is enabled and try again.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python script `fetch_drugs.py` that queries the openFDA API for drug data
- document how to run the script in README

## Testing
- `python3 fetch_drugs.py` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_685dcfd0e3b08330888e87fac1b3ce45